### PR TITLE
Archspec now has its own release number.

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,5 @@
-Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
-Spack and Archspec Project Developers. See the top-level COPYRIGHT file 
-for details.
+Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+Archspec Project Developers. See the top-level COPYRIGHT file for details.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 # Archspec (Go bindings)
 Archspec aims at providing a standard set of human-understandable labels for
 various aspects of a system architecture  like CPU, network fabrics, etc. and
-APIs to detect, query and compare them. 
+APIs to detect, query and compare them.
 
-This project grew out of [Spack](https://spack.io/) and is currently under 
-active development. At present it supports APIs to detect and model 
+This project grew out of [Spack](https://spack.io/) and is currently under
+active development. At present it supports APIs to detect and model
 compatibility relationships among different CPU microarchitectures.
 
 ## License
@@ -19,9 +19,11 @@ option.
 All new contributions must be made under both the MIT and Apache-2.0
 licenses.
 
-See [LICENSE-MIT](https://github.com/archspec/archspec/blob/master/LICENSE-MIT),
-[LICENSE-APACHE](https://github.com/archspec/archspec/blob/master/LICENSE-APACHE),
-[COPYRIGHT](https://github.com/archspec/archspec/blob/master/COPYRIGHT), and
-[NOTICE](https://github.com/archspec/archspec/blob/master/NOTICE) for details.
+See [LICENSE-MIT](https://github.com/archspec/archspec-go/blob/master/LICENSE-MIT),
+[LICENSE-APACHE](https://github.com/archspec/archspec-go/blob/master/LICENSE-APACHE),
+[COPYRIGHT](https://github.com/archspec/archspec-go/blob/master/COPYRIGHT), and
+[NOTICE](https://github.com/archspec/archspec-go/blob/master/NOTICE) for details.
 
 SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+LLNL-CODE-811653

--- a/archspec/cpu/alias.go
+++ b/archspec/cpu/alias.go
@@ -1,3 +1,8 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Archspec Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 package cpu
 
 import (

--- a/archspec/cpu/json.go
+++ b/archspec/cpu/json.go
@@ -1,3 +1,8 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Archspec Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 package cpu
 
 //go:generate statik -src ../json/cpu -f

--- a/archspec/cpu/microarchitecture.go
+++ b/archspec/cpu/microarchitecture.go
@@ -1,3 +1,8 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Archspec Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 package cpu
 
 import (

--- a/archspec/cpu/microarchitecture_test.go
+++ b/archspec/cpu/microarchitecture_test.go
@@ -1,3 +1,8 @@
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Archspec Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 package cpu
 
 import "testing"


### PR DESCRIPTION
Archspec grew out of Spack, so we initially just labeled it that way, but it's really its own project. I put in a separate code release for Archspec, so now we don't have to mention Spack in all the code headers.

- [x] added the new release number, LLNL-CODE-811653, to `README.md`
- [x] changed all the SPDX headers to only mention archspec
- [x] changed copyright year to start of archspec