### PR TITLE
External library should not debug print

### DIFF
--- a/archspec/cpu/alias.go
+++ b/archspec/cpu/alias.go
@@ -6,8 +6,6 @@
 package cpu
 
 import (
-	"fmt"
-
 	"github.com/scylladb/go-set/strset"
 )
 
@@ -28,7 +26,6 @@ func parseFeatureAliases() map[string]aliasPredicate {
 			Families: *strset.New(value.Families...),
 		}
 	}
-	fmt.Println(aliases)
 	return aliases
 }
 


### PR DESCRIPTION
It looks like aliases is currently printing, and it's really confusing in my library because it's not expected for a dependency. I think maybe this was here for debugging and should have been removed?