### PR TITLE
feat: add parsing of compilers to archspec-go

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,6 @@ on:
   schedule:
   - cron: "0 4 * * *"
 
-
 jobs:
   unit:
     strategy:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![codecov](https://codecov.io/gh/archspec/archspec-go/branch/master/graph/badge.svg)](https://codecov.io/gh/archspec/archspec-go)
 
 # Archspec (Go bindings)
+
 Archspec aims at providing a standard set of human-understandable labels for
 various aspects of a system architecture  like CPU, network fabrics, etc. and
 APIs to detect, query and compare them.
@@ -9,6 +10,22 @@ APIs to detect, query and compare them.
 This project grew out of [Spack](https://spack.io/) and is currently under
 active development. At present it supports APIs to detect and model
 compatibility relationships among different CPU microarchitectures.
+
+## Development
+
+You will need Go minimum version 1.19. From the root of the repository, you'll want to ensure you 
+have the git submodule init and updated:
+
+```bash
+git submodule init
+git submodule update
+```
+
+This adds the json microarchitecture files in [archspec/json](archspec/json). To test:
+
+```bash
+go test ./...
+```
 
 ## License
 

--- a/archspec/cpu/json.go
+++ b/archspec/cpu/json.go
@@ -21,7 +21,13 @@ type jMicroarchitecture struct {
 	Vendor     string                 `json:"vendor"`
 	Features   []string               `json:"features"`
 	Generation int                    `json:"generation"`
-	Compilers  map[string]interface{} `json:"compilers"`
+	Compilers  map[string][]jCompiler `json:"compilers,omitempty"`
+}
+
+type jCompiler struct {
+	Name     string `json:"name,omitempty"`
+	Flags    string `json:"flags,omitempty"`
+	Versions string `json:"versions,omitempty"`
 }
 
 type jFeatureAlias struct {

--- a/archspec/cpu/microarchitecture.go
+++ b/archspec/cpu/microarchitecture.go
@@ -18,6 +18,7 @@ type Microarchitecture struct {
 	Vendor     string
 	Features   strset.Set
 	Generation int
+	Compilers  map[string][]jCompiler
 }
 
 // TARGETS is a list of all the CPU microarchitectures known to the package
@@ -71,6 +72,7 @@ func addItem(targets map[string]Microarchitecture, name string, value jMicroarch
 		Features:   *strset.New(value.Features...),
 		Generation: value.Generation,
 		Parents:    parents,
+		Compilers:  value.Compilers,
 	}
 }
 

--- a/archspec/cpu/microarchitecture_test.go
+++ b/archspec/cpu/microarchitecture_test.go
@@ -5,7 +5,10 @@
 
 package cpu
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 const tick = "\u2713"
 const cross = "\u2717"
@@ -131,6 +134,42 @@ func TestCompatibleWith(t *testing.T) {
 				return
 			}
 			t.Log(target, "not compatible with", earlierUarch, tick)
+		})
+	}
+}
+
+func TestCompilers(t *testing.T) {
+	testTargets := map[string]int{
+		"icelake":     8,
+		"k10":         7,
+		"steamroller": 7,
+		"thunderx2":   2,
+		"power8le":    3,
+	}
+
+	for target, count := range testTargets {
+		t.Run(target, func(t *testing.T) {
+			tgt := TARGETS[target]
+			fmt.Printf("Found %d in family %s\n", len(tgt.Compilers), tgt.Name)
+
+			// Ensure fields are not empty!
+			for _, compilers := range tgt.Compilers {
+				for _, compiler := range compilers {
+					if compiler.Flags == "" {
+						t.Error(target, cross)
+						return
+					}
+					if compiler.Versions == "" {
+						t.Error(target, cross)
+						return
+					}
+				}
+			}
+			if len(tgt.Compilers) != count {
+				t.Error(target, cross)
+				return
+			}
+			t.Log(target, tick)
 		})
 	}
 }


### PR DESCRIPTION
Problem: we currently have compilers in the metadata but they are not parsed. Having compilers for use in the library would be hugely useful. Solution: add them to be parsed.

This will close #14 